### PR TITLE
Simpler way to handle errors when creating directory

### DIFF
--- a/01.scripts/treemix_iterations.sh
+++ b/01.scripts/treemix_iterations.sh
@@ -4,11 +4,8 @@
 TIMESTAMP=$(date +%Y-%m-%d_%Hh%Mm%Ss)
 LOG_DIR="10-log_files"
 
-if [[ ! -d "$LOG_DIR" ]]
-then
-    echo "creating log folder" 
-    mkdir 10-log_files
-fi
+echo "creating log folder" 
+mkdir 10-log_files 2>/dev/null
 
 id=$1
 mig=$2


### PR DESCRIPTION
You don't need to check anything. If the directory exists, mkdir will do nothing and you can redirect the error message to `/dev/null`